### PR TITLE
Resolve cache fix

### DIFF
--- a/EFCache/CacheTransactionHandler.cs
+++ b/EFCache/CacheTransactionHandler.cs
@@ -88,7 +88,7 @@ namespace EFCache
 
             if (entitySets != null)
             {
-                ResolveCache(transaction.Connection).InvalidateSets(entitySets.Distinct());
+                ResolveCache(interceptionContext.Connection).InvalidateSets(entitySets.Distinct());
             }
         }
 

--- a/EFCache/CachingCommand.cs
+++ b/EFCache/CachingCommand.cs
@@ -179,7 +179,8 @@ namespace EFCache
 
                 if (!_commandTreeFacts.IsQuery)
                 {
-                    _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name));
+                    _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name),
+                        DbConnection);
                 }
 
                 return result;
@@ -188,7 +189,7 @@ namespace EFCache
             var key = CreateKey();
 
             object value;
-            if (_cacheTransactionHandler.GetItem(Transaction, key, out value))
+            if (_cacheTransactionHandler.GetItem(Transaction, key, DbConnection, out value))
             {
                 return new CachingReader((CachedResults)value);
             }
@@ -217,7 +218,7 @@ namespace EFCache
 
                 if (!_commandTreeFacts.IsQuery)
                 {
-                    _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name));
+                    _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name), DbConnection);
                 }
 
                 return result;
@@ -226,7 +227,7 @@ namespace EFCache
             var key = CreateKey();
 
             object value;
-            if (_cacheTransactionHandler.GetItem(Transaction, key, out value))
+            if (_cacheTransactionHandler.GetItem(Transaction, key, DbConnection, out value))
             {
                 return new CachingReader((CachedResults)value);
             }
@@ -270,7 +271,8 @@ namespace EFCache
                     cachedResults,
                     _commandTreeFacts.AffectedEntitySets.Select(s => s.Name),
                     slidingExpiration,
-                    absoluteExpiration);
+                    absoluteExpiration,
+                    DbConnection);
             }
 
             return new CachingReader(cachedResults);
@@ -321,7 +323,8 @@ namespace EFCache
         {
             if (recordsAffected > 0 && _commandTreeFacts.AffectedEntitySets.Any())
             {
-                _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name));
+                _cacheTransactionHandler.InvalidateSets(Transaction, _commandTreeFacts.AffectedEntitySets.Select(s => s.Name),
+                    DbConnection);
             }
         }
 
@@ -336,7 +339,7 @@ namespace EFCache
 
             object value;
 
-            if (_cacheTransactionHandler.GetItem(Transaction, key, out value))
+            if (_cacheTransactionHandler.GetItem(Transaction, key, DbConnection, out value))
             {
                 return value;
             }
@@ -353,7 +356,8 @@ namespace EFCache
                 value,
                 _commandTreeFacts.AffectedEntitySets.Select(s => s.Name),
                 slidingExpiration,
-                absoluteExpiration);
+                absoluteExpiration,
+                DbConnection);
 
             return value;
         }
@@ -370,7 +374,7 @@ namespace EFCache
 
             object value;
 
-            if (_cacheTransactionHandler.GetItem(Transaction, key, out value))
+            if (_cacheTransactionHandler.GetItem(Transaction, key, DbConnection, out value))
             {
                 return value;
             }
@@ -387,7 +391,8 @@ namespace EFCache
                 value,
                 _commandTreeFacts.AffectedEntitySets.Select(s => s.Name),
                 slidingExpiration,
-                absoluteExpiration);
+                absoluteExpiration,
+                DbConnection);
 
             return value;
         }

--- a/EFCache/CommandTreeFacts.cs
+++ b/EFCache/CommandTreeFacts.cs
@@ -49,9 +49,9 @@ namespace EFCache
                 var entitySetMappings =
                 containerMapping.EntitySetMappings.Where(
                     esm => esm.ModificationFunctionMappings.Any(
-                        mfm => mfm.DeleteFunctionMapping.Function == edmFunction ||
-                        mfm.InsertFunctionMapping.Function == edmFunction ||
-                        mfm.UpdateFunctionMapping.Function == edmFunction));
+                        mfm => mfm.DeleteFunctionMapping?.Function == edmFunction ||
+                        mfm.InsertFunctionMapping?.Function == edmFunction ||
+                        mfm.UpdateFunctionMapping?.Function == edmFunction));
 
                 AffectedEntitySets =
                     (from esm in entitySetMappings

--- a/EFCache/InMemoryCache.cs
+++ b/EFCache/InMemoryCache.cs
@@ -133,7 +133,12 @@ namespace EFCache
             }
         }
 
-        public void Purge(bool removeUnexpiredItems = false)
+        public void Purge()
+        {
+            Purge(false);
+        }
+
+        public void Purge(bool removeUnexpiredItems)
         {
             lock (_cache)
             {

--- a/EFCache/InMemoryCache.cs
+++ b/EFCache/InMemoryCache.cs
@@ -133,7 +133,7 @@ namespace EFCache
             }
         }
 
-        public void Purge()
+        public void Purge(bool removeUnexpiredItems = false)
         {
             lock (_cache)
             {
@@ -142,7 +142,7 @@ namespace EFCache
 
                 foreach (var item in _cache)
                 {
-                    if (EntryExpired(item.Value, now))
+                    if (removeUnexpiredItems || EntryExpired(item.Value, now))
                     {
                         itemsToRemove.Add(item.Key);
                     }

--- a/EFCache/Properties/AssemblyInfo.cs
+++ b/EFCache/Properties/AssemblyInfo.cs
@@ -31,8 +31,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.2.0")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyVersion("1.1.3.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 #if INTERNALSVISIBLETOENABLED
 

--- a/EFCache/Properties/AssemblyInfo.cs
+++ b/EFCache/Properties/AssemblyInfo.cs
@@ -31,8 +31,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.1.0")]
-[assembly: AssemblyFileVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.2.0")]
 
 #if INTERNALSVISIBLETOENABLED
 

--- a/EFCacheTests/CachingCommandTests.cs
+++ b/EFCacheTests/CachingCommandTests.cs
@@ -399,7 +399,8 @@ namespace EFCache
                     It.Is<CachedResults>(r => r.Results.Count == 1 && r.RecordsAffected == 1 && r.TableMetadata.Length == 2),
                     It.Is<IEnumerable<string>>(es => es.SequenceEqual(new [] { "ES1", "ES2"})),
                     slidingExpiration,
-                    absoluteExpiration),
+                    absoluteExpiration,
+                    It.IsNotNull<DbConnection>()),
                 Times.Once);
         }
 
@@ -425,7 +426,7 @@ namespace EFCache
                 object value;
 
                 mockTransactionHandler.Verify(
-                    c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value),
+                    c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), It.IsAny<DbConnection>(), out value),
                     Times.Never());
 
                 mockTransactionHandler.Verify(
@@ -435,7 +436,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+                        It.IsAny<DbConnection>()),
                     Times.Never);
             }
         }
@@ -462,7 +464,7 @@ namespace EFCache
                 object value;
 
                 mockTransactionHandler.Verify(
-                    c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value),
+                    c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), It.IsAny<DbConnection>(), out value),
                     Times.Never());
 
                 mockTransactionHandler.Verify(
@@ -472,7 +474,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+                        It.IsAny<DbConnection>()),
                     Times.Never);
             }
         }
@@ -521,7 +524,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+                        It.IsAny<DbConnection>()),
                     Times.Never);
             }
         }
@@ -573,7 +577,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+                        It.IsNotNull<DbConnection>()),
                     Times.Once);
             }
         }
@@ -587,7 +592,7 @@ namespace EFCache
 
             var mockTransactionHandler = new Mock<CacheTransactionHandler>(Mock.Of<ICache>());
             mockTransactionHandler
-                .Setup(h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value))
+                .Setup(h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), It.IsAny<DbConnection>(), out value))
                 .Returns(true);
 
             var cachingCommand = new CachingCommand(
@@ -650,7 +655,7 @@ namespace EFCache
             object value;
 
             mockTransactionHandler.Verify(
-                h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value), Times.Once);
+                h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", It.IsNotNull<DbConnection>(), out value), Times.Once);
 
             mockCommand.Verify(c => c.ExecuteScalar(), Times.Once);
 
@@ -661,7 +666,8 @@ namespace EFCache
                     retValue,
                     new[] {"ES1", "ES2"},
                     slidingExpiration,
-                    absoluteExpiration),
+                    absoluteExpiration,
+                    It.IsNotNull<DbConnection>()),
                     Times.Once);
         }
 
@@ -685,7 +691,7 @@ namespace EFCache
 
             var mockTransactionHandler = new Mock<CacheTransactionHandler>(Mock.Of<ICache>());
             mockTransactionHandler
-                .Setup(h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out retValue))
+                .Setup(h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", It.IsAny<DbConnection>(), out retValue))
                 .Returns(true);
 
             var result =
@@ -699,7 +705,7 @@ namespace EFCache
 
             object value;
             mockTransactionHandler.Verify(
-                h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value), Times.Once);
+                h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", It.IsNotNull<DbConnection>(), out value), Times.Once);
 
             mockCommand.Verify(h => h.ExecuteScalar(), Times.Never);
 
@@ -710,7 +716,8 @@ namespace EFCache
                     It.IsAny<object>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<TimeSpan>(),
-                    It.IsAny<DateTimeOffset>()),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<DbConnection>()),
                     Times.Never);
         }
 
@@ -738,7 +745,7 @@ namespace EFCache
             Assert.Same(retValue, result);
             object value;
             mockTransactionHandler.Verify(
-                h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value), Times.Never);
+                h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), It.IsAny<DbConnection>(), out value), Times.Never);
 
             mockCommand.Verify(c => c.ExecuteScalar(), Times.Once);
 
@@ -749,7 +756,8 @@ namespace EFCache
                     It.IsAny<object>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<TimeSpan>(),
-                    It.IsAny<DateTimeOffset>()),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<DbConnection>()),
                     Times.Never);
         }
 
@@ -782,7 +790,7 @@ namespace EFCache
             Assert.Same(retValue, result);
             object value;
             mockTransactionHandler.Verify(
-                h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value), Times.Never);
+                h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), It.IsAny<DbConnection>(), out value), Times.Never);
 
             mockCommand.Verify(c => c.ExecuteScalar(), Times.Once);
 
@@ -793,7 +801,8 @@ namespace EFCache
                     It.IsAny<object>(),
                     It.IsAny<IEnumerable<string>>(),
                     It.IsAny<TimeSpan>(),
-                    It.IsAny<DateTimeOffset>()),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<DbConnection>()),
                     Times.Never);
         }
 
@@ -817,7 +826,7 @@ namespace EFCache
             Assert.Equal(rowsAffected, 1);
             mockCommand.Verify(c => c.ExecuteNonQuery(), Times.Once());
             mockTransactionHandler
-                .Verify(h => h.InvalidateSets(transaction, new[] { "ES1", "ES2" }), Times.Once());
+                .Verify(h => h.InvalidateSets(transaction, new[] { "ES1", "ES2" }, It.IsNotNull<DbConnection>()), Times.Once());
         }
 
         [Fact]
@@ -839,7 +848,7 @@ namespace EFCache
             Assert.Equal(rowsAffected, 0);
             mockCommand.Verify(c => c.ExecuteNonQuery(), Times.Once());
             mockTransactionHandler
-                .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>()), Times.Never());
+                .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>(), It.IsAny<DbConnection>()), Times.Never());
         }
 
         [Fact]
@@ -861,7 +870,7 @@ namespace EFCache
             Assert.Equal(rowsAffected, 1);
             mockCommand.Verify(c => c.ExecuteNonQuery(), Times.Once());
             mockTransactionHandler
-                .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>()), Times.Never());
+                .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>(), It.IsNotNull<DbConnection>()), Times.Never());
         }
 
         [Fact]
@@ -1039,7 +1048,7 @@ namespace EFCache
                 Assert.Equal(rowsAffected, 1);
                 mockCommand.Verify(c => c.ExecuteNonQueryAsync(It.IsAny<CancellationToken>()), Times.Once());
                 mockTransactionHandler
-                    .Verify(h => h.InvalidateSets(transaction, new[] {"ES1", "ES2"}), Times.Once());
+                    .Verify(h => h.InvalidateSets(transaction, new[] {"ES1", "ES2"}, It.IsNotNull<DbConnection>()), Times.Once());
             }
 
             [Fact]
@@ -1061,7 +1070,7 @@ namespace EFCache
                 Assert.Equal(rowsAffected, 0);
                 mockCommand.Verify(c => c.ExecuteNonQueryAsync(It.IsAny<CancellationToken>()), Times.Once());
                 mockTransactionHandler
-                    .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>()),
+                    .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>(), It.IsAny<DbConnection>()),
                         Times.Never());
             }
 
@@ -1086,7 +1095,7 @@ namespace EFCache
                 Assert.Equal(rowsAffected, 1);
                 mockCommand.Verify(c => c.ExecuteNonQueryAsync(It.IsAny<CancellationToken>()), Times.Once());
                 mockTransactionHandler
-                    .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>()),
+                    .Verify(h => h.InvalidateSets(It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<string>>(), It.IsAny<DbConnection>()),
                         Times.Never());
             }
 
@@ -1155,7 +1164,7 @@ namespace EFCache
                 object value;
 
                 mockTransactionHandler.Verify(
-                    h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value), Times.Once);
+                    h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", It.IsNotNull<DbConnection>(), out value), Times.Once);
 
                 mockCommand.Verify(c => c.ExecuteScalarAsync(It.IsAny<CancellationToken>()), Times.Once);
 
@@ -1166,7 +1175,8 @@ namespace EFCache
                         retValue,
                         new[] {"ES1", "ES2"},
                         slidingExpiration,
-                        absoluteExpiration),
+                        absoluteExpiration,
+                        It.IsNotNull<DbConnection>()),
                     Times.Once);
             }
 
@@ -1190,7 +1200,7 @@ namespace EFCache
 
                 var mockTransactionHandler = new Mock<CacheTransactionHandler>(Mock.Of<ICache>());
                 mockTransactionHandler
-                    .Setup(h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out retValue))
+                    .Setup(h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", It.IsAny<DbConnection>(), out retValue))
                     .Returns(true);
 
                 var result =
@@ -1204,7 +1214,7 @@ namespace EFCache
 
                 object value;
                 mockTransactionHandler.Verify(
-                    h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", out value), Times.Once);
+                    h => h.GetItem(transaction, "db_Exec_P1=ZZZ_P2=123", It.IsNotNull<DbConnection>(), out value), Times.Once);
 
                 mockCommand.Verify(h => h.ExecuteScalarAsync(It.IsAny<CancellationToken>()), Times.Never);
 
@@ -1215,7 +1225,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+                        It.IsAny<DbConnection>()),
                     Times.Never);
             }
 
@@ -1243,7 +1254,7 @@ namespace EFCache
                 Assert.Same(retValue, result);
                 object value;
                 mockTransactionHandler.Verify(
-                    h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value), Times.Never);
+                    h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), It.IsAny<DbConnection>(), out value), Times.Never);
 
                 mockCommand.Verify(c => c.ExecuteScalarAsync(It.IsAny<CancellationToken>()), Times.Once);
 
@@ -1254,7 +1265,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(),
+                        It.IsAny<DbConnection>()),
                     Times.Never);
             }
 
@@ -1287,7 +1299,7 @@ namespace EFCache
                 Assert.Same(retValue, result);
                 object value;
                 mockTransactionHandler.Verify(
-                    h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value), Times.Never);
+                    h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), It.IsAny<DbConnection>(), out value), Times.Never);
 
                 mockCommand.Verify(c => c.ExecuteScalarAsync(It.IsAny<CancellationToken>()), Times.Once);
 
@@ -1298,7 +1310,8 @@ namespace EFCache
                         It.IsAny<object>(),
                         It.IsAny<IEnumerable<string>>(),
                         It.IsAny<TimeSpan>(),
-                        It.IsAny<DateTimeOffset>()),
+                        It.IsAny<DateTimeOffset>(), 
+                        It.IsAny<DbConnection>()),
                     Times.Never);
             }
 
@@ -1429,7 +1442,8 @@ namespace EFCache
                             r => r.Results.Count == 1 && r.RecordsAffected == 1 && r.TableMetadata.Length == 2),
                         It.Is<IEnumerable<string>>(es => es.SequenceEqual(new[] {"ES1", "ES2"})),
                         slidingExpiration,
-                        absoluteExpiration),
+                        absoluteExpiration,
+                        It.IsNotNull<DbConnection>()),
                     Times.Once);
             }
 
@@ -1455,7 +1469,7 @@ namespace EFCache
                     object value;
 
                     mockTransactionHandler.Verify(
-                        c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value),
+                        c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), It.IsAny<DbConnection>(), out value),
                         Times.Never());
 
                     mockTransactionHandler.Verify(
@@ -1465,7 +1479,8 @@ namespace EFCache
                             It.IsAny<object>(),
                             It.IsAny<IEnumerable<string>>(),
                             It.IsAny<TimeSpan>(),
-                            It.IsAny<DateTimeOffset>()),
+                            It.IsAny<DateTimeOffset>(),
+                            It.IsAny<DbConnection>()),
                         Times.Never);
                 }
             }
@@ -1492,7 +1507,7 @@ namespace EFCache
                     object value;
 
                     mockTransactionHandler.Verify(
-                        c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value),
+                        c => c.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), It.IsAny<DbConnection>(), out value),
                         Times.Never());
 
                     mockTransactionHandler.Verify(
@@ -1502,7 +1517,8 @@ namespace EFCache
                             It.IsAny<object>(),
                             It.IsAny<IEnumerable<string>>(),
                             It.IsAny<TimeSpan>(),
-                            It.IsAny<DateTimeOffset>()),
+                            It.IsAny<DateTimeOffset>(),
+                            It.IsAny<DbConnection>()),
                         Times.Never);
                 }
             }
@@ -1551,7 +1567,8 @@ namespace EFCache
                             It.IsAny<object>(),
                             It.IsAny<IEnumerable<string>>(),
                             It.IsAny<TimeSpan>(),
-                            It.IsAny<DateTimeOffset>()),
+                            It.IsAny<DateTimeOffset>(),
+                            It.IsAny<DbConnection>()),
                         Times.Never);
                 }
             }
@@ -1565,7 +1582,7 @@ namespace EFCache
 
                 var mockTransactionHandler = new Mock<CacheTransactionHandler>(Mock.Of<ICache>());
                 mockTransactionHandler
-                    .Setup(h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), out value))
+                    .Setup(h => h.GetItem(It.IsAny<DbTransaction>(), It.IsAny<string>(), It.IsNotNull<DbConnection>(), out value))
                     .Returns(true);
 
                 var cachingCommand = new CachingCommand(

--- a/EFCacheTests/EFCacheTests.csproj
+++ b/EFCacheTests/EFCacheTests.csproj
@@ -99,7 +99,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EFCache\EFCache.csproj">

--- a/EFCacheTests/InMemoryCacheTests.cs
+++ b/EFCacheTests/InMemoryCacheTests.cs
@@ -116,6 +116,21 @@ namespace EFCache
         }
 
         [Fact]
+        public void Purge_removing_unexpired_items_removes_all_items_from_cache()
+        {
+            var cache = new InMemoryCache();
+
+            cache.PutItem("1", new object(), new[] { "ES1", "ES2" }, TimeSpan.MaxValue, DateTimeOffset.Now.AddMinutes(-1));
+            cache.PutItem("2", new object(), new[] { "ES1", "ES2" }, TimeSpan.MaxValue, DateTimeOffset.MaxValue);
+
+            Assert.Equal(2, cache.Count);
+
+            cache.Purge(true);
+
+            Assert.Equal(0, cache.Count);
+        }
+
+        [Fact]
         public void GetItem_validates_parametes()
         {
             object item;

--- a/tools/EntityFramework.Cache.nuspec
+++ b/tools/EntityFramework.Cache.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>EntityFramework.Cache</id>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <authors>Pawel "moozzyk" Kadluczka</authors>
     <title>Second Level Cache for Entity Framework 6.1+.</title>
     <licenseUrl>https://github.com/moozzyk/EFCache/blob/84d7862bff8d43d495a93560dbee5ac0380ed0fe/License.txt</licenseUrl>

--- a/tools/EntityFramework.Cache.nuspec
+++ b/tools/EntityFramework.Cache.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>EntityFramework.Cache</id>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <authors>Pawel "moozzyk" Kadluczka</authors>
     <title>Second Level Cache for Entity Framework 6.1+.</title>
     <licenseUrl>https://github.com/moozzyk/EFCache/blob/84d7862bff8d43d495a93560dbee5ac0380ed0fe/License.txt</licenseUrl>


### PR DESCRIPTION
This addresses a null reference error that occurs at times resolving the db connection from the transaction to the interception context.

This should be merged after the upstream master is merged.